### PR TITLE
Allow matching submit and file input elements without Quark's classnames

### DIFF
--- a/assets/fixfilefield-validate.js
+++ b/assets/fixfilefield-validate.js
@@ -36,15 +36,15 @@ window.addEventListener("DOMContentLoaded", (event) => {
       if (form !== null) {
         // Prevent the form from submitting immediately
         event.preventDefault();
-        document.addEventListener('click', function (event) {
+        form.addEventListener('click', function (event) {
           const clickedElement = event.target;
         
           // Check if the clicked element is the Submit button or the Reset button
-          if (clickedElement.matches('.btn[type="submit"]')) {
+          if (clickedElement.matches('input[type="submit"], button[type="submit"]')) {
             // Submit button clicked
             console.log('Submit button clicked');
 
-            const fileInputs = form.querySelectorAll('input.form-input[type="file"]');
+            const fileInputs = form.querySelectorAll('input[type="file"]');
             let allValid = true;
 
             // Process each set of file fields separately


### PR DESCRIPTION
[As discussed](https://discourse.getgrav.org/t/workaround-for-using-validate-required-on-form-file-fields/23532/18), currently this plugin's JS matches classnames specific to Quark theme (and maybe others). This PR broadens the DOM matching expressions to support almost any theme.